### PR TITLE
Add block scope

### DIFF
--- a/src/internal/ast.rs
+++ b/src/internal/ast.rs
@@ -1,6 +1,7 @@
 use super::token::{Literal, Token};
 
 #[allow(dead_code)]
+#[derive(Clone)]
 pub enum Stmt {
     FunctionDef {
         name: Expr,
@@ -33,6 +34,7 @@ pub enum Stmt {
 }
 
 #[allow(dead_code)]
+#[derive(Clone)]
 pub enum Expr {
     Binary(Box<Expr>, Token, Box<Expr>),
     Unary(Token, Box<Expr>),

--- a/src/internal/ast.rs
+++ b/src/internal/ast.rs
@@ -29,7 +29,7 @@ pub enum Stmt {
     Break,
     Continue,
     Echo(Expr),
-    Block(Token, Box<Stmt>, Token),
+    Block(Vec<Stmt>),
 }
 
 #[allow(dead_code)]

--- a/src/internal/environment.rs
+++ b/src/internal/environment.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use super::error_reporter::{ErrorReporter, ErrorType};
 use super::token::{Literal, Token};
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Environment {
     store: HashMap<String, Literal>,
     outer: Option<Box<Environment>>,
@@ -11,8 +11,11 @@ pub struct Environment {
 
 impl Environment {
     /// Creates a new outer scope.
-    pub fn new_outer(&mut self, outer: Box<Environment>) {
-        self.outer = Some(outer);
+    pub fn new_outer(outer: Box<Environment>) -> Self {
+        Self {
+            outer: Some(outer),
+            ..Default::default()
+        }
     }
 
     /// Returns the literal value bound to the name.

--- a/src/internal/environment.rs
+++ b/src/internal/environment.rs
@@ -6,13 +6,23 @@ use super::token::{Literal, Token};
 #[derive(Default)]
 pub struct Environment {
     store: HashMap<String, Literal>,
+    outer: Option<Box<Environment>>,
 }
 
 impl Environment {
+    /// Creates a new outer scope.
+    pub fn new_outer(&mut self, outer: Box<Environment>) {
+        self.outer = Some(outer);
+    }
+
     /// Returns the literal value bound to the name.
     pub fn get(&self, name: &Token) -> Literal {
         if let Some(value) = self.store.get(&name.lexeme) {
             return value.to_owned();
+        }
+
+        if let Some(outer_env) = &self.outer {
+            return outer_env.get(name);
         }
 
         self.token_error(

--- a/src/internal/interpreter.rs
+++ b/src/internal/interpreter.rs
@@ -35,7 +35,7 @@ impl Interpreter {
                 let value = self.visit_expr(expr);
                 println!("{}", value);
             }
-            Stmt::Block(_, _, _) => todo!(),
+            Stmt::Block(_) => todo!(),
         }
     }
 

--- a/src/internal/interpreter.rs
+++ b/src/internal/interpreter.rs
@@ -1,4 +1,4 @@
-use super::ast::{self, Visitor};
+use super::ast::{Expr, Program, Stmt, Visitor};
 use super::environment::Environment;
 use super::token::Literal;
 use super::token_type::TokenType;
@@ -10,15 +10,13 @@ pub struct Interpreter {
 
 impl Interpreter {
     /// Interprets a program.
-    pub fn interpret(&mut self, program: ast::Program) {
+    pub fn interpret(&mut self, program: Program) {
         for stmt in program.get().iter() {
             self.walk_stmt(stmt);
         }
     }
 
-    fn walk_stmt(&mut self, stmt: &ast::Stmt) {
-        use ast::Stmt;
-
+    fn walk_stmt(&mut self, stmt: &Stmt) {
         match stmt {
             Stmt::FunctionDef { .. } => todo!(),
             Stmt::Return(_, _, _) => todo!(),
@@ -35,11 +33,26 @@ impl Interpreter {
                 let value = self.visit_expr(expr);
                 println!("{}", value);
             }
-            Stmt::Block(_) => todo!(),
+            Stmt::Block(statements) => {
+                self.execute_block(
+                    statements.to_owned(),
+                    Environment::new_outer(Box::new(self.environment.to_owned())),
+                );
+            }
         }
     }
 
-    fn interpret_binary(&mut self, lhs: &ast::Expr, op: TokenType, rhs: &ast::Expr) -> Literal {
+    fn execute_block(&mut self, statements: Vec<Stmt>, environment: Environment) {
+        let previous = self.environment.clone();
+        self.environment = environment;
+
+        for stmt in statements.iter() {
+            self.walk_stmt(stmt);
+        }
+        self.environment = previous;
+    }
+
+    fn interpret_binary(&mut self, lhs: &Expr, op: TokenType, rhs: &Expr) -> Literal {
         let left = self.visit_expr(lhs);
         let right = self.visit_expr(rhs);
 
@@ -75,7 +88,7 @@ impl Interpreter {
         }
     }
 
-    fn interpret_unary(&mut self, op: TokenType, rhs: &ast::Expr) -> Literal {
+    fn interpret_unary(&mut self, op: TokenType, rhs: &Expr) -> Literal {
         let right = self.visit_expr(rhs);
 
         match (op, &right) {
@@ -90,9 +103,7 @@ impl Interpreter {
 }
 
 impl Visitor<Literal> for Interpreter {
-    fn visit_expr(&mut self, expr: &ast::Expr) -> Literal {
-        use ast::Expr;
-
+    fn visit_expr(&mut self, expr: &Expr) -> Literal {
         match expr {
             Expr::Binary(lhs, op, rhs) => self.interpret_binary(lhs, op.ty, rhs),
             Expr::Unary(op, rhs) => self.interpret_unary(op.ty, rhs),

--- a/src/internal/parser.rs
+++ b/src/internal/parser.rs
@@ -108,12 +108,15 @@ impl Parser {
     /// Parses block statement.
     fn block_statement(&mut self) -> Result<Stmt, ParseError> {
         let mut statements: Vec<Stmt> = Vec::new();
+        self.consume(TokenType::Newline)?; // enter block after newline
 
         while !self.has_type(TokenType::RBrace) && !self.is_at_end() {
             statements.push(self.statement()?);
         }
 
         self.consume(TokenType::RBrace)?;
+        self.consume(TokenType::Newline)?;
+
         Ok(Stmt::Block(statements))
     }
 

--- a/src/internal/parser.rs
+++ b/src/internal/parser.rs
@@ -85,6 +85,8 @@ impl Parser {
     fn statement(&mut self) -> Result<Stmt, ParseError> {
         if self.match_type(TokenType::Echo) {
             return self.echo_statement();
+        } else if self.match_type(TokenType::LBrace) {
+            return self.block_statement();
         }
         self.expression_statement()
     }
@@ -101,6 +103,18 @@ impl Parser {
         let value = self.expression()?;
         self.consume(TokenType::Newline)?;
         Ok(Stmt::Echo(value))
+    }
+
+    /// Parses block statement.
+    fn block_statement(&mut self) -> Result<Stmt, ParseError> {
+        let mut statements: Vec<Stmt> = Vec::new();
+
+        while !self.has_type(TokenType::RBrace) && !self.is_at_end() {
+            statements.push(self.statement()?);
+        }
+
+        self.consume(TokenType::RBrace)?;
+        Ok(Stmt::Block(statements))
     }
 
     /// Expands to the `equality` rule.


### PR DESCRIPTION
Add support for statements inside "{ }" curly blocks. The block is lexically scoped.